### PR TITLE
fix: Exclude `Name` tag to prevent ALB conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ github/
 *.ovpn
 
 *.zip
+account-map/


### PR DESCRIPTION
## what
- Exclude `Name` from tags
- Resolve `tflint` warnings

## why
Services like `echo-server` were using `k8s-common` ALB instead of the provisioned `alb-controller-ingress-group` ALB, despite having `ingress_type: "alb"` configured.

The root cause was tag conflicts: the ALB Controller's `defaultTags` (from `module.this.tags`) applied `Name: acme-plat-euc1-dev`, while the ALB controller ingress group applied Name: `acme-plat-euc1-dev-alb-controller-ingress-group`. These conflicting `Name` tags prevented the AWS Load Balancer Controller from reconciling ingresses into the target group.

Ingresses should manage their own tags rather than inheriting the tags from this component.


## references
- https://github.com/cloudposse-terraform-components/aws-eks-alb-controller/pull/49


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated Terraform to use consistent indexing for namespaces and annotations.
  - Adjusted tag generation to exclude the “Name” tag from Kubernetes and AWS resources.
- Documentation
  - Added inline comments clarifying tag exclusions and indexing choices.
- Chores
  - Added account-map/ to .gitignore to prevent committing local files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->