### PR TITLE
Add variable for EKS Auto Mode configuration

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -159,3 +159,18 @@ variable "tls_enabled" {
   description = "Whether to enable TLS on the ingress. Requires an ACM certificate for the host."
   default     = true
 }
+
+variable "auto_mode_enabled" {
+  type        = bool
+  description = <<-EOT
+    Enable EKS Auto Mode. When enabled, AWS manages compute (via managed Karpenter),
+    networking (elastic load balancing), and storage (EBS block storage) for the cluster.
+    Requires Kubernetes 1.29+ and AWS provider >= 5.79.0.
+    Cannot be used with `karpenter_iam_role_enabled = true` (Auto Mode includes managed Karpenter).
+    When enabled, the addons `vpc-cni`, `kube-proxy`, `coredns`, and `aws-ebs-csi-driver` are
+    managed by Auto Mode and should be removed from the `addons` variable (or use `auto_mode_upgrade`
+    for brownfield migration).
+    EOT
+  default     = false
+  nullable    = false
+}


### PR DESCRIPTION
Added a new variable 'auto_mode_enabled' to control EKS Auto Mode with detailed description.

## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EKS Auto Mode configuration option to enable automatic cluster management. When enabled, review and adjust addon configurations and IAM role settings as needed for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->